### PR TITLE
Remove target setting for esp32 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ export.bat
 
 :: Build and flash
 cd D:\path\to\project
-idf.py set-target esp32
 idf.py build
 idf.py -p COM10 flash
 ```


### PR DESCRIPTION
Removed the line setting the target to esp32 in the build instructions. This command resets the sdkconfig, resulting in the project not compiling. Not necessary and actually harmful